### PR TITLE
Support Python3

### DIFF
--- a/nkf.c
+++ b/nkf.c
@@ -116,7 +116,11 @@ pynkf_convert(unsigned char* str, int strlen, char* opts, int optslen)
   }
 
   *pynkf_optr = 0;
-  res = PyString_FromString(pynkf_outbuf);
+  #if PY_MAJOR_VERSION >= 3
+    res = PyBytes_FromString(pynkf_outbuf);
+  #else
+    res = PyString_FromString(pynkf_outbuf);
+  #endif
   PyMem_Free(pynkf_outbuf);
   return res;
 }
@@ -139,8 +143,11 @@ pynkf_convert_guess(unsigned char* str, int strlen)
   kanji_convert(NULL);
 
   codename = get_guessed_code();
-
-  res = PyString_FromString(codename);
+  #if PY_MAJOR_VERSION >= 3
+    res = PyBytes_FromString(codename);
+  #else
+    res = PyString_FromString(codename);
+  #endif
   return res;
 }
 
@@ -186,10 +193,33 @@ nkfmethods[] = {
   {NULL, NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef
+moduledef = {
+  PyModuleDef_HEAD_INIT,
+  "nkf",
+  NULL,
+  NULL,
+  nkfmethods,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+};
+
 /* Module initialization function */
+PyObject *
+PyInit_nkf(void)
+#else
 void
 initnkf(void)
+#endif
 {
-  Py_InitModule("nkf", nkfmethods);
+  #if PY_MAJOR_VERSION >= 3
+    PyObject *module = PyModule_Create(&moduledef);
+    return module;
+  #else
+    Py_InitModule("nkf", nkfmethods);
+  #endif
 }
 #endif

--- a/nkf_codecs.py
+++ b/nkf_codecs.py
@@ -115,7 +115,7 @@ class iso2022_jp_nkf_StreamReader(iso2022_jp_nkf_Codec, codecs.StreamReader):
         if pos >= 0:
             match = re_designations.match(data, pos)
             if not match:
-                raise UnicodeError, "unknown designation"
+                raise UnicodeError("unknown designation")
             self.charset = CHARSETS[match.group()]
             if self.charset in [JISX0208_1978, JISX0208_1983, JISX0212_1990] and \
                (len(data) - match.end()) % 2 == 1:
@@ -442,7 +442,7 @@ if __name__ == '__main__':
     overrideEncodings()
 
     for encoding in encoding_list:
-        print '%s: encode(), decode()' % encoding
+        print('%s: encode(), decode()' % encoding)
         encoded = unicoded.encode(encoding)
         assert encoded.decode(encoding) == unicoded
 
@@ -451,7 +451,7 @@ if __name__ == '__main__':
         encoder, decoder, reader, writer = codecs.lookup(encoding)
         for func_name in ['read', 'readline', 'readlines']:
             for size in [None, -1] + range(1, 33) + [64, 128, 256, 512, 1024]:
-                print '%s: %s(%s)' % (encoding, func_name, str(size))
+                print('%s: %s(%s)' % (encoding, func_name, str(size)))
 
                 istream = reader(StringIO.StringIO(text))
                 ostream = writer(StringIO.StringIO())


### PR DESCRIPTION
Python 3.4で利用できるようにしました。
よろしくお願いいたします。
- Switch C-modules used in `nkf.c` between Python 2 and Python 3 because
  C-API in Python 3 has changed from Python 2.
- Modify syntax of print and raise function for Python 3.
