### PR TITLE
nkf.c: Change guess result type from Bytes to Unicode

### DIFF
--- a/nkf.c
+++ b/nkf.c
@@ -144,7 +144,7 @@ pynkf_convert_guess(unsigned char* str, int strlen)
 
   codename = get_guessed_code();
   #if PY_MAJOR_VERSION >= 3
-    res = PyBytes_FromString(codename);
+    res = PyUnicode_FromString(codename);
   #else
     res = PyString_FromString(codename);
   #endif


### PR DESCRIPTION
Python3ではBytes型の文字列を引数として扱わない関数が多いので、
利便性を上げるためPython 3の`nkf.guess`でUnicodeの値を返すようにしました。
よろしくお願いします。

For example:
- PyBytes_FromString

```
>>> import nkf
>>> char = 'あ'.encode('eucjp')
>>> encoding = nkf.guess(char)
>>> type(encoding)
<class 'bytes'>
>>> char.decode(encoding)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: decode() argument 1 must be str, not bytes
```
- PyUnicode_FromString

```
>>> import nkf
>>> char = 'あ'.encode('eucjp')
>>> encoding = nkf.guess(char)
>>> type(encoding)
<class 'str'>
>>> char.decode(encoding)
'あ'
```
