### PR TITLE
Updated int type for PEP353

### DIFF
--- a/nkf.c
+++ b/nkf.c
@@ -13,6 +13,9 @@
  * THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE.
  */
 
+// Support https://github.com/python/cpython/issues/85115
+#define PY_SSIZE_T_CLEAN
+
 #include "Python.h"
 #include <setjmp.h>
 
@@ -157,9 +160,9 @@ static
 PyObject *pynkf_nkf(PyObject *self, PyObject *args)
 {
   unsigned char *str;
-  int strlen;
+  Py_ssize_t strlen;
   char *opts;
-  int optslen;
+  Py_ssize_t optslen;
   PyObject* res;
 
   if (!PyArg_ParseTuple(args, "s#s#", &opts, &optslen, &str, &strlen)) {
@@ -175,7 +178,7 @@ static
 PyObject *pynkf_guess(PyObject *self, PyObject *args)
 {
   unsigned char *str;
-  int strlen;
+  Py_ssize_t strlen;
   PyObject* res;
 
   if (!PyArg_ParseTuple(args, "s#", &str, &strlen)) {


### PR DESCRIPTION
Due to breaking change in Python API starting from 3.10, python-nkf does not function anymore.

```
$ ipython
Python 3.10.7 (tags/v3.10.7:6cc6b13, Sep  5 2022, 14:08:36) [MSC v.1933 64 b
it (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import nkf

In [2]: nkf.guess('hogehoge')
---------------------------------------------------------------------------
SystemError                               Traceback (most recent call last)
Cell In [2], line 1
----> 1 nkf.guess('hogehoge')

SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
```

This is caused by an intentional incompatibility introduced from 3.10:

- https://github.com/python/cpython/issues/85115
- https://peps.python.org/pep-0353/

This patch updates int type to Py_ssize_t and adds PY_SSIZE_T_CLEAN, so it will work again.
That said, since int values are still used everywhere in nkf.c, it still needs further update to handle input longer than 32bit limit. This patch does not handle that. 
